### PR TITLE
Fix theme toggle initialization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { cvData } from './data/cvData';
 import { useProjects } from './hooks/useProjects';
 
@@ -9,11 +9,16 @@ function useTheme() {
     return saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches);
   });
 
+  // Set the data-theme attribute on mount and when isDark changes
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+  }, [isDark]);
+
   const toggleTheme = () => {
     const newTheme = !isDark;
     setIsDark(newTheme);
     localStorage.setItem('theme', newTheme ? 'dark' : 'light');
-    document.documentElement.setAttribute('data-theme', newTheme ? 'dark' : 'light');
+    // data-theme will be set automatically by the useEffect above
   };
 
   return { isDark, toggleTheme };


### PR DESCRIPTION
Fix theme toggle initialization to ensure the correct icon is displayed on page load.

The `data-theme` attribute on the document element was only updated when the theme was manually toggled, leading to a mismatch between the UI's theme icon and the actual applied theme on initial load. This change ensures the `data-theme` attribute is correctly set based on the current theme state immediately when the component mounts and whenever the theme state changes.

---
Linear Issue: [MAN-49](https://linear.app/manugomez/issue/MAN-49/fix-theme-toggle)

<a href="https://cursor.com/background-agent?bcId=bc-581ca70e-75e7-4053-8fa2-e6c5a1142018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-581ca70e-75e7-4053-8fa2-e6c5a1142018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

