### PR TITLE
Fix hover text visibility on view projects button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -201,6 +201,7 @@ a:hover {
 
 .btn-primary:hover {
   background-color: var(--accent-hover);
+  color: white;
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }


### PR DESCRIPTION
Add `color: white` to `.btn-primary:hover` to ensure text remains visible on hover.

---
Linear Issue: [MAN-64](https://linear.app/manugomez/issue/MAN-64/fix-hover-in-view-projects-button)

<a href="https://cursor.com/background-agent?bcId=bc-d2a64030-b042-4195-ae21-ea17016aee3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2a64030-b042-4195-ae21-ea17016aee3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

