### PR TITLE
Adjust card and tag colors for dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,7 @@
   --border: #374151;
   --accent: #60a5fa;
   --accent-hover: #3b82f6;
-  --card-bg: #1a1a1a;
+  --card-bg: #0a0a0a;
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.2);
 }
@@ -306,8 +306,21 @@ section {
 
 /* Dark mode tech tag improvement */
 [data-theme="dark"] .tech-tag {
-  background-color: #000000;
-  color: #ffffff;
+  background-color: rgba(96, 165, 250, 0.2);
+  color: #e0f2fe;
+  border: 1px solid rgba(96, 165, 250, 0.3);
+}
+
+/* Enhanced dark theme project card styling */
+[data-theme="dark"] .project-card {
+  border: 1px solid #333;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .project-card:hover {
+  border: 1px solid #444;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.7);
+  transform: translateY(-4px);
 }
 
 .project-link {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,10 +1,11 @@
 /* Base styles */
 body {
-  background-color: #f1f3f4;
+  background-color: var(--light-gray);
   margin: 0;
   padding: 0;
   min-height: 100vh;
   overflow: hidden;
+  transition: background-color 0.3s ease;
 }
 
 #root {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -8,6 +8,11 @@ body {
   transition: background-color 0.3s ease;
 }
 
+/* Ensure good contrast for dark theme body */
+[data-theme="dark"] body {
+  background-color: var(--light-gray);
+}
+
 #root {
   width: 100vw;
   height: 100vh;

--- a/src/styles/floating.css
+++ b/src/styles/floating.css
@@ -132,9 +132,9 @@
 
 /* Improve background tech items in dark theme */
 [data-theme="dark"] .background-tech-item {
-  background: rgba(96, 165, 250, 0.3);
+  background: rgba(96, 165, 250, 0.4);
   color: #e0f2fe;
-  border: 1px solid rgba(96, 165, 250, 0.2);
+  border: 1px solid rgba(96, 165, 250, 0.3);
 }
 
 /* Name styles */
@@ -189,6 +189,17 @@
   opacity: 1;
 }
 
+/* Enhanced dark theme floating card styling */
+[data-theme="dark"] .floating-card {
+  border: 1px solid #333;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .floating-card:hover {
+  border: 1px solid #444;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.7);
+}
+
 .floating-card h3,
 .floating-card h4 {
   color: var(--primary-color);
@@ -239,14 +250,15 @@
 
 /* Dark mode tech item improvement for better contrast */
 [data-theme="dark"] .tech-item {
-  background: rgba(96, 165, 250, 0.2);
+  background: rgba(96, 165, 250, 0.25);
   color: #e0f2fe;
-  border: 1px solid rgba(96, 165, 250, 0.3);
+  border: 1px solid rgba(96, 165, 250, 0.4);
 }
 
 [data-theme="dark"] .tech-item:hover {
-  background: rgba(96, 165, 250, 0.3);
+  background: rgba(96, 165, 250, 0.35);
   color: #ffffff;
+  transform: translateY(-1px);
 }
 
 .project-link {

--- a/src/styles/floating.css
+++ b/src/styles/floating.css
@@ -127,6 +127,14 @@
   border-radius: 15px;
   font-size: 0.875rem;
   color: white;
+  transition: all 0.3s ease;
+}
+
+/* Improve background tech items in dark theme */
+[data-theme="dark"] .background-tech-item {
+  background: rgba(96, 165, 250, 0.3);
+  color: #e0f2fe;
+  border: 1px solid rgba(96, 165, 250, 0.2);
 }
 
 /* Name styles */
@@ -166,10 +174,10 @@
 /* Card content styles */
 .floating-card {
   position: relative;
-  background: white;
+  background: var(--card-background);
   padding: 20px;
   border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow);
   width: 100%;
   min-height: 120px;
   color: var(--text-color);
@@ -198,12 +206,13 @@
 
 /* Project card specific styles */
 .project-card {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--card-background);
   backdrop-filter: blur(10px);
   border-radius: 15px;
   padding: 1.5rem;
   width: 100%;
   color: var(--text-color);
+  opacity: 0.95;
 }
 
 .project-card h4 {
@@ -225,11 +234,18 @@
   border-radius: 15px;
   font-size: 0.875rem;
   color: var(--primary-color);
+  transition: all 0.3s ease;
 }
 
 /* Dark mode tech item improvement for better contrast */
 [data-theme="dark"] .tech-item {
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(96, 165, 250, 0.2);
+  color: #e0f2fe;
+  border: 1px solid rgba(96, 165, 250, 0.3);
+}
+
+[data-theme="dark"] .tech-item:hover {
+  background: rgba(96, 165, 250, 0.3);
   color: #ffffff;
 }
 

--- a/src/styles/organized.css
+++ b/src/styles/organized.css
@@ -2,8 +2,8 @@
 .cv-container.organized {
   width: var(--paper-width);
   height: var(--paper-height);
-  background: white;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  background: var(--card-background);
+  box-shadow: var(--shadow);
   border-radius: 8px;
   position: relative;
   overflow: auto;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -29,7 +29,7 @@
   --primary-color: #60a5fa;
   --secondary-color: #d1d5db;
   --text-color: #ffffff;
-  --light-gray: #374151;
-  --card-background: #1a1a1a;
-  --shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  --light-gray: #0f0f0f;
+  --card-background: #0a0a0a;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 } 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,8 +1,10 @@
 :root {
+  /* Light theme colors */
   --primary-color: #1a73e8;
   --secondary-color: #5f6368;
   --text-color: #202124;
   --light-gray: #f8f9fa;
+  --card-background: #ffffff;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   --transition-time: 0.8s;
   --paper-width: min(800px, 90vh / 1.4142);
@@ -20,4 +22,14 @@
   /* Grid layout */
   --left-column-width: 40%;
   --right-column-width: 60%;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] {
+  --primary-color: #60a5fa;
+  --secondary-color: #d1d5db;
+  --text-color: #ffffff;
+  --light-gray: #374151;
+  --card-background: #1a1a1a;
+  --shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 } 


### PR DESCRIPTION
Fix card background and tag colors to be dark and lighter respectively in dark theme.

---
Linear Issue: [MAN-78](https://linear.app/manugomez/issue/MAN-78/fix-cards-background-color-so-its-dark-and-the-tags-color-is-lighter)

<a href="https://cursor.com/background-agent?bcId=bc-c731f0e8-069c-4794-abb0-3f697a3061cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c731f0e8-069c-4794-abb0-3f697a3061cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

